### PR TITLE
make color masks always uint32s (as in the C API)

### DIFF
--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -1365,3 +1365,13 @@ proc Point*[T: TNumber](x, y: T): TPoint = (x.cint, y.cint)
 proc Contains*(some: TRect; point: TPoint): bool = 
   return point.x >= some.x and point.x <= (some.x + some.w) and
           point.y >= some.y and point.y <= (some.y + some.h)
+
+proc SetHint*(name: cstring, value: cstring): bool {.
+  importc: "SDL_SetHint".}
+
+proc SetHintWithPriority*(name: cstring, value: cstring, priority: cint): bool {.
+  importc: "SDL_SetHintWithPriority".}
+
+proc GetHint*(name: cstring): cstring {.
+  importc: "SDL_GetHint".}
+


### PR DESCRIPTION
I have this code:

``` nimrod
  const # ARGB32
    amask = 0xff000000
    rmask = 0x00ff0000
    gmask = 0x0000ff00
    bmask = 0x000000ff

  let surface = sdl2.createRGBSurfaceFrom(cImage, w, h, 32, stride,
                                         rmask, gmask, bmask, amask)
```

It failed because the mask parameters are ints instead of unsigned ints, like in the C API.
