### PR TITLE
Update sdl2.nim

### DIFF
--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -8,7 +8,8 @@ export unsigned, strutils.`%`
 {. deadCodeElim: on .}
 
 when defined(SDL_Static):
-  static: echo "SDL2 will be statically linked."
+  static: echo "SDL2 will be statically linked. Please make sure you pass the correct compiler/linker flags "&
+    "(header search paths, library search paths, linked libraries)."
   #{.passl: gorge("pkg-config --libs sdl2").}
   #{.pragma: sdl_header, header: "<SDL2/SDL.h>".}
   #{.error: "Static linking SDL2 is disabled.".}


### PR DESCRIPTION
The only thing preventing sdl usage with iOS: enable static linking.
