### PR TITLE
SDL_GameController bindings

### DIFF
--- a/src/sdl2/gamecontroller.nim
+++ b/src/sdl2/gamecontroller.nim
@@ -120,7 +120,7 @@ proc mapping* (gameController: GameControllerPtr): cstring {.
 ##
 #   Is the joystick on this index supported by the game controller interface?
 # /
-proc isGameControler* (joystickIndex: cint): Bool32 {.
+proc isGameController* (joystickIndex: cint): Bool32 {.
   importc: "SDL_IsGameController".}
 
 
@@ -140,7 +140,7 @@ proc gameControllerNameForIndex* (joystickIndex: cint): cstring {.
 #
 #   \return A controller identifier, or NULL if an error occurred.
 # /
-proc gameControlerOpen* (joystickIndex: cint): GameControllerPtr {.
+proc gameControllerOpen* (joystickIndex: cint): GameControllerPtr {.
   importc: "SDL_GameControllerOpen".}
 
 ##

--- a/src/sdl2/gamecontroller.nim
+++ b/src/sdl2/gamecontroller.nim
@@ -26,6 +26,7 @@ discard """
 \file SDL_gamecontroller.h
 
 Include file for SDL game controller event handling
+
 """
 
 ##
@@ -57,6 +58,8 @@ type
   GameControllerButtonBind* = object
     bindType*: GameControllerBindType
     value, hatMask*: cint
+
+{.push callconv: cdecl, dynlib: sdl2.LibName.}
 
 proc button* (self: GameControllerButtonBind): cint =
   result = self.value
@@ -210,13 +213,13 @@ proc gameControllerGetAxisFromString* (pchString: cstring): GameControllerAxis {
 #   turn this axis enum into a string mapping
 # /
 proc gameControllerGetStringForAxis* (axis: GameControllerAxis): cstring {.
-  importc: "GameControllerGetStringForAxis".}
+  importc: "SDL_GameControllerGetStringForAxis".}
 
 ##
 #   Get the SDL joystick layer binding for this controller button mapping
 # /
 proc getBindForAxis* (gameController: GameControllerPtr, axis: GameControllerAxis): GameControllerButtonBind {.
-  importc: "GameControllerGetBindForAxis".}
+  importc: "SDL_GameControllerGetBindForAxis".}
 
 ##
 #   Get the current state of an axis control on a game controller.
@@ -269,7 +272,7 @@ proc gameControllerGetStringForButton* (button: GameControllerButton): cstring {
 #   Get the SDL joystick layer binding for this controller button mapping
 # /
 proc getBindForButton* (gameController: GameControllerPtr, button: GameControllerButton): GameControllerButtonBind {.
-  importc: "SDL_GameControllerButtonBind".}
+  importc: "SDL_GameControllerGetBindForButton".}
 
 
 ##
@@ -286,3 +289,4 @@ proc getButton* (gameController: GameControllerPtr, button: GameControllerButton
 proc close* (gameController: GameControllerPtr) {.
   importc: "SDL_GameControllerClose".}
 
+{.pop.}

--- a/src/sdl2/gamecontroller.nim
+++ b/src/sdl2/gamecontroller.nim
@@ -1,0 +1,288 @@
+import "../sdl2"
+import "joystick"
+
+discard """
+  Simple DirectMedia Layer
+  Copyright (C) 1997-2014 Sam Lantinga <slouken@libsdl.org>
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+
+
+\file SDL_gamecontroller.h
+
+Include file for SDL game controller event handling
+"""
+
+##
+#   \file SDL_gamecontroller.h
+#
+#   In order to use these functions, SDL_Init() must have been called
+#   with the ::SDL_INIT_JOYSTICK flag.  This causes SDL to scan the system
+#   for game controllers, and load appropriate drivers.
+#
+#   If you would like to receive controller updates while the application
+#   is in the background, you should set the following hint before calling
+#   SDL_Init(): SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS
+#
+
+# The gamecontroller structure used to identify an SDL game controller# /
+type
+  GameController* = object
+  GameControllerPtr* = ptr GameController
+
+  GameControllerBindType* {.size: sizeof(cint).} = enum
+    SDL_CONTROLLER_BINDTYPE_NONE,
+    SDL_CONTROLLER_BINDTYPE_BUTTON,
+    SDL_CONTROLLER_BINDTYPE_AXIS,
+    SDL_CONTROLLER_BINDTYPE_HAT
+
+# Get the SDL joystick layer binding for this controller button/axis mapping
+
+type
+  GameControllerButtonBind* = object
+    bindType*: GameControllerBindType
+    value, hatMask*: cint
+
+proc button* (self: GameControllerButtonBind): cint =
+  result = self.value
+
+proc axis* (self: GameControllerButtonBind): cint =
+  result = self.value
+
+proc hat* (self: GameControllerButtonBind): cint =
+  result = self.value
+
+##
+#  To count the number of game controllers in the system for the following:
+#  int nJoysticks = SDL_NumJoysticks();
+#  int nGameControllers = 0;
+#  for ( int i = 0; i < nJoysticks; i++ ) {
+#      if ( SDL_IsGameController(i) ) {
+#          nGameControllers++;
+#      }
+#  }
+#
+#  Using the SDL_HINT_GAMECONTROLLERCONFIG hint or the SDL_GameControllerAddMapping you can add support for controllers SDL is unaware of or cause an existing controller to have a different binding. The format is:
+#  guid,name,mappings
+#
+#  Where GUID is the string value from SDL_JoystickGetGUIDString(), name is the human readable string for the device and mappings are controller mappings to joystick ones.
+#  Under Windows there is a reserved GUID of "xinput" that covers any XInput devices.
+#  The mapping format for joystick is:
+#      bX - a joystick button, index X
+#      hX.Y - hat X with value Y
+#      aX - axis X of the joystick
+#  Buttons can be used as a controller axis and vice versa.
+#
+#  This string shows an example of a valid mapping for a controller
+#  "341a3608000000000000504944564944,Afterglow PS3 Controller,a:b1,b:b2,y:b3,x:b0,start:b9,guide:b12,back:b8,dpup:h0.1,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,leftshoulder:b4,rightshoulder:b5,leftstick:b10,rightstick:b11,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:b6,righttrigger:b7",
+#
+# /
+
+##
+#   Add or update an existing mapping configuration
+#
+#  \return 1 if mapping is added, 0 if updated, -1 on error
+# /
+proc gameControllerAddMapping* (mappingString: cstring): cint {.
+  importc: "SDL_GameControllerAddMapping".}
+
+##
+#   Get a mapping string for a GUID
+#
+#   \return the mapping string.  Must be freed with SDL_free.  Returns NULL if no mapping is available
+# /
+proc gameControllerMappingForGUID* (guid: JoystickGuid): cstring {.
+  importc: "SDL_GameControllerMappingForGUID".}
+
+##
+#   Get a mapping string for an open GameController
+#
+#   \return the mapping string.  Must be freed with SDL_free.  Returns NULL if no mapping is available
+# /
+proc mapping* (gameController: GameControllerPtr): cstring {.
+  importc: "SDL_GameControllerMapping".}
+
+##
+#   Is the joystick on this index supported by the game controller interface?
+# /
+proc isGameControler* (joystickIndex: cint): Bool32 {.
+  importc: "SDL_IsGameController".}
+
+
+##
+#   Get the implementation dependent name of a game controller.
+#   This can be called before any controllers are opened.
+#   If no name can be found, this function returns NULL.
+# /
+proc gameControllerNameForIndex* (joystickIndex: cint): cstring {.
+  importc: "SDL_GameControllerNameForIndex".}
+
+##
+#   Open a game controller for use.
+#   The index passed as an argument refers to the N'th game controller on the system.
+#   This index is the value which will identify this controller in future controller
+#   events.
+#
+#   \return A controller identifier, or NULL if an error occurred.
+# /
+proc gameControlerOpen* (joystickIndex: cint): GameControllerPtr {.
+  importc: "SDL_GameControllerOpen".}
+
+##
+#   Return the name for this currently opened controller
+# /
+proc name* (gameController: GameControllerPtr): cstring {.
+  importc: "SDL_GameControllerName".}
+
+##
+#   Returns SDL_TRUE if the controller has been opened and currently connected,
+#   or SDL_FALSE if it has not.
+# /
+proc getAttached* (gameController: GameControllerPtr): Bool32 {.
+  importc: "SDL_GameControllerGetAttached".}
+
+##
+#   Get the underlying joystick object used by a controller
+# /
+proc getJoystick* (gameController: GameControllerPtr): JoystickPtr {.
+  importc: "SDL_GameControllerGetJoystick".}
+
+##
+#   Enable/disable controller event polling.
+#
+#   If controller events are disabled, you must call SDL_GameControllerUpdate()
+#   yourself and check the state of the controller when you want controller
+#   information.
+#
+#   The state can be one of ::SDL_QUERY, ::SDL_ENABLE or ::SDL_IGNORE.
+# /
+proc gameControllerEventState* (state: cint): cint {.
+  importc: "SDL_GameControllerEventState".}
+
+##
+#   Update the current state of the open game controllers.
+#
+#   This is called automatically by the event loop if any game controller
+#   events are enabled.
+# /
+proc gameControllerUpdate* () {.
+  importc: "SDL_GameControllerUpdate".}
+
+
+##
+#   The list of axes available from a controller
+# /
+type
+  GameControllerAxis* {.size: sizeof(cint).} = enum
+    SDL_CONTROLLER_AXIS_INVALID = -1,
+    SDL_CONTROLLER_AXIS_LEFTX,
+    SDL_CONTROLLER_AXIS_LEFTY,
+    SDL_CONTROLLER_AXIS_RIGHTX,
+    SDL_CONTROLLER_AXIS_RIGHTY,
+    SDL_CONTROLLER_AXIS_TRIGGERLEFT,
+    SDL_CONTROLLER_AXIS_TRIGGERRIGHT,
+    SDL_CONTROLLER_AXIS_MAX
+
+converter toInt* (some: GameControllerAxis): uint8 = uint8(some)
+
+##
+#   turn this string into a axis mapping
+# /
+proc gameControllerGetAxisFromString* (pchString: cstring): GameControllerAxis {.
+  importc: "SDL_GameControllerGetAxisFromString".}
+
+##
+#   turn this axis enum into a string mapping
+# /
+proc gameControllerGetStringForAxis* (axis: GameControllerAxis): cstring {.
+  importc: "GameControllerGetStringForAxis".}
+
+##
+#   Get the SDL joystick layer binding for this controller button mapping
+# /
+proc getBindForAxis* (gameController: GameControllerPtr, axis: GameControllerAxis): GameControllerButtonBind {.
+  importc: "GameControllerGetBindForAxis".}
+
+##
+#   Get the current state of an axis control on a game controller.
+#
+#   The state is a value ranging from -32768 to 32767.
+#
+#   The axis indices start at index 0.
+# /
+proc getAxis* (gameController: GameControllerPtr, axis: GameControllerAxis): int16 {.
+  importc: "SDL_GameControllerGetAxis".}
+
+##
+#   The list of buttons available from a controller
+# /
+type
+  GameControllerButton* {.size: sizeof(cint).} = enum
+    SDL_CONTROLLER_BUTTON_INVALID = -1,
+    SDL_CONTROLLER_BUTTON_A,
+    SDL_CONTROLLER_BUTTON_B,
+    SDL_CONTROLLER_BUTTON_X,
+    SDL_CONTROLLER_BUTTON_Y,
+    SDL_CONTROLLER_BUTTON_BACK,
+    SDL_CONTROLLER_BUTTON_GUIDE,
+    SDL_CONTROLLER_BUTTON_START,
+    SDL_CONTROLLER_BUTTON_LEFTSTICK,
+    SDL_CONTROLLER_BUTTON_RIGHTSTICK,
+    SDL_CONTROLLER_BUTTON_LEFTSHOULDER,
+    SDL_CONTROLLER_BUTTON_RIGHTSHOULDER,
+    SDL_CONTROLLER_BUTTON_DPAD_UP,
+    SDL_CONTROLLER_BUTTON_DPAD_DOWN,
+    SDL_CONTROLLER_BUTTON_DPAD_LEFT,
+    SDL_CONTROLLER_BUTTON_DPAD_RIGHT,
+    SDL_CONTROLLER_BUTTON_MAX
+
+converter toInt* (some: GameControllerButton): uint8 = uint8(some)
+
+##
+#   turn this string into a button mapping
+# /
+proc gameControllerGetButtonFromString* (pchString: cstring): GameControllerButton {.
+  importc: "SDL_GameControllerGetButtonFromString".}
+
+##
+#   turn this button enum into a string mapping
+# /
+proc gameControllerGetStringForButton* (button: GameControllerButton): cstring {.
+  importc: "SDL_GameControllerGetStringForButton".}
+
+##
+#   Get the SDL joystick layer binding for this controller button mapping
+# /
+proc getBindForButton* (gameController: GameControllerPtr, button: GameControllerButton): GameControllerButtonBind {.
+  importc: "SDL_GameControllerButtonBind".}
+
+
+##
+#   Get the current state of a button on a game controller.
+#
+#   The button indices start at index 0.
+# /
+proc getButton* (gameController: GameControllerPtr, button: GameControllerButton): uint8 {.
+  importc: "SDL_GameControllerGetButton".}
+
+##
+#   Close a controller previously opened with SDL_GameControllerOpen().
+# /
+proc close* (gameController: GameControllerPtr) {.
+  importc: "SDL_GameControllerClose".}
+

--- a/src/sdl2/gamecontroller.nim
+++ b/src/sdl2/gamecontroller.nim
@@ -58,11 +58,11 @@ type
   GameControllerButtonBind* = object
     case bindType*: GameControllerBindType
       of SDL_CONTROLLER_BINDTYPE_NONE:
-        pad1, pad2: cint
+        nil
       of SDL_CONTROLLER_BINDTYPE_BUTTON:
-        button*, pad3: cint
+        button*: cint
       of SDL_CONTROLLER_BINDTYPE_AXIS:
-        axis*, pad4: cint
+        axis*: cint
       of SDL_CONTROLLER_BINDTYPE_HAT:
         hat*, hatMask*: cint
 

--- a/src/sdl2/gamecontroller.nim
+++ b/src/sdl2/gamecontroller.nim
@@ -56,19 +56,17 @@ type
 
 type
   GameControllerButtonBind* = object
-    bindType*: GameControllerBindType
-    value, hatMask*: cint
+    case bindType*: GameControllerBindType
+      of SDL_CONTROLLER_BINDTYPE_NONE:
+        pad1, pad2: cint
+      of SDL_CONTROLLER_BINDTYPE_BUTTON:
+        button*, pad3: cint
+      of SDL_CONTROLLER_BINDTYPE_AXIS:
+        axis*, pad4: cint
+      of SDL_CONTROLLER_BINDTYPE_HAT:
+        hat*, hatMask*: cint
 
 {.push callconv: cdecl, dynlib: sdl2.LibName.}
-
-proc button* (self: GameControllerButtonBind): cint =
-  result = self.value
-
-proc axis* (self: GameControllerButtonBind): cint =
-  result = self.value
-
-proc hat* (self: GameControllerButtonBind): cint =
-  result = self.value
 
 ##
 #  To count the number of game controllers in the system for the following:

--- a/src/sdl2/joystick.nim
+++ b/src/sdl2/joystick.nim
@@ -93,7 +93,7 @@ proc joystickOpen*(device_index: cint): JoystickPtr {.
 #   If no name can be found, this function returns NULL.
 # /
 proc joystickName*(joystick: ptr Joystick): cstring {.importc: "SDL_JoystickName".}
-proc name* (joystick: ptr Joystick) {.inline.} = joystick.joystickName
+proc name* (joystick: ptr Joystick): cstring {.inline.} = joystick.joystickName
 
 ##
 #   Return the GUID for the joystick at this index
@@ -106,7 +106,7 @@ proc joystickGetDeviceGUID*(device_index: cint): JoystickGUID {.
 #
 proc joystickGetGUID*(joystick: JoystickPtr): JoystickGUID {.
   importc: "SDL_JoystickGetGUID".}
-proc getGUID* (joystick: JoystickPtr) {.inline.} = joystick.JoystickGetGUID
+proc getGUID* (joystick: JoystickPtr): JoystickGUID {.inline.} = joystick.joystickGetGUID
 
 # *
 #   Return a string representation for this guid. pszGUID must point to at least 33 bytes
@@ -126,21 +126,21 @@ proc joystickGetGUIDFromString*(pchGUID: cstring): JoystickGUID {.
 #
 proc joystickGetAttached*(joystick: JoystickPtr): Bool32 {.
   importc: "SDL_JoystickGetAttached".}
-proc getAttached* (joystick: JoystickPtr) {.inline.} = joystick.JoystickGetAttached
+proc getAttached* (joystick: JoystickPtr): Bool32 {.inline.} = joystick.joystickGetAttached
 
 # *
 #   Get the instance ID of an opened joystick or -1 if the joystick is invalid.
 #
 proc joystickInstanceID*(joystick: JoystickPtr): JoystickID {.
   importc: "SDL_JoystickInstanceID".}
-proc instanceID* (joystick: JoystickPtr) {.inline.} = joystick.JoystickInstanceID
+proc instanceID* (joystick: JoystickPtr): JoystickID {.inline.} = joystick.joystickInstanceID
 
 # *
 #   Get the number of general axis controls on a joystick.
 #
 proc joystickNumAxes*(joystick: JoystickPtr): cint {.
   importc: "SDL_JoystickNumAxes".}
-proc numAxes* (joystick: JoystickPtr) {.inline.} = joystick.JoystickNumAxes
+proc numAxes* (joystick: JoystickPtr): cint {.inline.} = joystick.joystickNumAxes
 
 # *
 #   Get the number of trackballs on a joystick.
@@ -151,21 +151,21 @@ proc numAxes* (joystick: JoystickPtr) {.inline.} = joystick.JoystickNumAxes
 #
 proc joystickNumBalls*(joystick: JoystickPtr): cint {.
   importc: "SDL_JoystickNumBalls".}
-proc numBalls* (joystick: JoystickPtr) {.inline.} = joystick.JoystickNumBalls
+proc numBalls* (joystick: JoystickPtr): cint {.inline.} = joystick.joystickNumBalls
 
 #
 #   Get the number of POV hats on a joystick.
 #
 proc joystickNumHats*(joystick: JoystickPtr): cint {.
   importc: "SDL_JoystickNumHats".}
-proc numHats* (joystick: JoystickPtr) {.inline.} = joystick.JoystickNumHats
+proc numHats* (joystick: JoystickPtr): cint {.inline.} = joystick.joystickNumHats
 
 #
 #   Get the number of buttons on a joystick.
 #
 proc joystickNumButtons*(joystick: JoystickPtr): cint {.
   importc: "SDL_JoystickNumButtons".}
-proc numButtons* (joystick: JoystickPtr) {.inline.} = joystick.JoystickNumButtons
+proc numButtons* (joystick: JoystickPtr): cint {.inline.} = joystick.joystickNumButtons
 
 #
 #   Update the current state of the open joysticks.
@@ -194,9 +194,9 @@ proc joystickEventState*(state: cint): cint {.
 #
 #   The axis indices start at index 0.
 #
-proc joystickGetAxis*(joystick: JoystickPtr, axis: cint): Int16 {.
+proc joystickGetAxis*(joystick: JoystickPtr, axis: cint): int16 {.
   importc: "SDL_JoystickGetAxis".}
-proc getAxis* (joystick: JoystickPtr) {.inline.} = joystick.JoystickGetAxis(axis)
+proc getAxis* (joystick: JoystickPtr, axis: cint): int16 {.inline.} = joystick.joystickGetAxis(axis)
 
 #
 #   \name Hat positions
@@ -230,8 +230,9 @@ const
 #            - ::SDL_HAT_LEFTUP
 #            - ::SDL_HAT_LEFTDOWN
 #
-proc joystickGetHat*(joystick: JoystickPtr, hat: cint): Uint8
-proc getHat* (joystick: JoystickPtr) {.inline.} = joystick.JoystickGetHat(hat)
+proc joystickGetHat*(joystick: JoystickPtr, hat: cint): uint8 {.
+  importc: "SDL_JoystickGetHat".}
+proc getHat* (joystick: JoystickPtr, hat: cint): uint8 {.inline.} = joystick.joystickGetHat(hat)
 
 #
 #   Get the ball axis change since the last poll.
@@ -240,22 +241,25 @@ proc getHat* (joystick: JoystickPtr) {.inline.} = joystick.JoystickGetHat(hat)
 #
 #   The ball indices start at index 0.
 #
-proc joystickGetBall*(joystick: JoystickPtr, ball: cint, dx: ptr cint, dy: ptr cint): cint
-proc getBall* (joystick: JoystickPtr) {.inline.} = joystick.JoystickGetBall(ball, dx, dy)
+proc joystickGetBall*(joystick: JoystickPtr, ball: cint, dx: ptr cint, dy: ptr cint): cint {.
+  importc: "SDL_JoystickGetBall".}
+proc getBall* (joystick: JoystickPtr, ball: cint, dx: ptr cint, dy: ptr cint): cint {.inline.} = joystick.joystickGetBall(ball, dx, dy)
 
 #
 #   Get the current state of a button on a joystick.
 #
 #   The button indices start at index 0.
 #
-proc joystickGetButton*(joystick: JoystickPtr, button: cint): Uint8
-proc getButton* (joystick: JoystickPtr) {.inline.} = joystick.JoystickGetButton(button)
+proc joystickGetButton*(joystick: JoystickPtr, button: cint): uint8 {.
+  importc: "SDL_JoystickGetButton".}
+proc getButton* (joystick: JoystickPtr, button: cint): uint8 {.inline.} = joystick.joystickGetButton(button)
 
 #
 #   Close a joystick previously opened with SDL_JoystickOpen().
 #
-proc joystickClose*(joystick: JoystickPtr)
-proc close* (joystick: JoystickPtr) {.inline.} = joystick.JoystickClose()
+proc joystickClose*(joystick: JoystickPtr) {.
+  importc: "SDL_JoystickClose".}
+proc close* (joystick: JoystickPtr) {.inline.} = joystick.joystickClose()
 
 # Ends C function definitions when using C++
 


### PR DESCRIPTION
Adds a new module, gamecontroller.nim, with bindings for the SDL_GameController functions and types. Also fixes compile errors in the joystick module, which this module depends on.