### PR TITLE
Fixed KeyReleased and KeyPressed constants

### DIFF
--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -210,7 +210,7 @@ type
     ## should also be discardable
   Bool32* {.size: sizeof(cint).} = enum False32 = 0, True32 = 1 ##\
     ## SDL_bool
-  KeyState* {.size: sizeof(byte).} = enum KeyPressed = 0, KeyReleased
+  KeyState* {.size: sizeof(byte).} = enum KeyReleased = 0, KeyPressed
 
   KeySym* {.pure.} = object
     scancode*: cint ##Scancode


### PR DESCRIPTION
If I understood correctly, KeyReleased and KeyPressed constants are counterparts of SDL_RELEASED and SDL_PRESSED in C. In such case, they are incorrect. Here's a few lines from SDL_events.h:
```
/* General keyboard/mouse state definitions */
#define SDL_RELEASED    0
#define SDL_PRESSED 1
```