### PR TITLE
Added Missing MIX_DEFAULT_FORMAT constant

### DIFF
--- a/src/sdl2/mixer.nim
+++ b/src/sdl2/mixer.nim
@@ -37,13 +37,22 @@ else:
 
 import sdl2, sdl2.audio
 
-when false:
-  when SDL_BYTEORDER == SDL_LIL_ENDIAN:
-    const
-      MIX_DEFAULT_FORMAT = AUDIO_S16LSB
-  else:
-    const
-      MIX_DEFAULT_FORMAT = AUDIO_S16MSB
+const 
+  AUDIO_U8 = 0x8
+  AUDIO_S8 = 0x8008
+  AUDIO_U16LSB = 0x0010
+  AUDIO_S16LSB = 0x8010
+  AUDIO_U16MSB = 0x1010
+  AUDIO_S16MSB = 0x9010
+  AUDIO_U16 = AUDIO_U16LSB
+  AUDIO_S16 = AUDIO_S16LSB
+
+when cpuEndian == littleEndian:
+  const
+    MIX_DEFAULT_FORMAT* = AUDIO_S16LSB
+else:
+  const
+    MIX_DEFAULT_FORMAT* = AUDIO_S16MSB
 
 # Remove prefixes in our wrapper, we have modules in Nim:
 


### PR DESCRIPTION
Hello.

I tried porting some of my cpp code to nim, ran into the issue where MIX_DEFAULT_FORMAT was missing.  