### PR TITLE
SDL_JoystickId is int32

### DIFF
--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -118,15 +118,15 @@ type
     timestamp*: uint32
     which*: int32
     axis*: uint8
-    pad1,pad2: uint8
-    value*: cint
+    pad1,pad2,pad3: uint8
+    value*: int16
   JoyBallEventPtr* = ptr JoyBallEventObj
   JoyBallEventObj* = object
     kind*: EventType
     timestamp*: uint32
     which*: int32
-    ball*, pad1,pad2: uint8
-    xrel*,yrel*: int32
+    ball*, pad1,pad2,pad3: uint8
+    xrel*,yrel*: int16
   JoyHatEventPtr* = ptr JoyHatEventObj
   JoyHatEventObj* = object
     kind*: EventType

--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -116,7 +116,7 @@ type
   JoyAxisEventObj* = object
     kind*: EventType
     timestamp*: uint32
-    which*: uint8
+    which*: int32
     axis*: uint8
     pad1,pad2: uint8
     value*: cint
@@ -124,7 +124,8 @@ type
   JoyBallEventObj* = object
     kind*: EventType
     timestamp*: uint32
-    which*,ball*, pad1,pad2: uint8
+    which*: int32
+    ball*, pad1,pad2: uint8
     xrel*,yrel*: int32
   JoyHatEventPtr* = ptr JoyHatEventObj
   JoyHatEventObj* = object


### PR DESCRIPTION
I encountered an issue where my Joystick axis wasn't registering.
According to https://hg.libsdl.org/SDL/file/e12c38730512/include/SDL_joystick.h#l72 it should be an int32 rather than uint8.
Changing this got the joystick axis to work.