### PR TITLE
Add IMG_SavePNG

### DIFF
--- a/src/sdl2/image.nim
+++ b/src/sdl2/image.nim
@@ -79,6 +79,8 @@ proc loadXPM_RW*(src: RWopsPtr): SurfacePtr {.importc: "IMG_LoadXPM_RW".}
 proc loadXV_RW*(src: RWopsPtr): SurfacePtr {.importc: "IMG_LoadXV_RW".}
 proc loadWEBP_RW*(src: RWopsPtr): SurfacePtr {.importc: "IMG_LoadWEBP_RW".}
 proc readXPMFromArray*(xpm: cstringArray): SurfacePtr {.importc: "IMG_ReadXPMFromArray".}
+# Saving functions
+proc savePNG*(surface: SurfacePtr, file: cstring): cint {.importc: "IMG_SavePNG".}
 #"""
 
 {.pop.}


### PR DESCRIPTION
This PR adds the IMG_SavePNG function. 

Every one ends up using it or implementing one at some point. The controversial part is that this function is not "documented." But is really useful otherwise you have to import another library.

Its been with SDL since 02 Jun 2013 and ton of people have used it..
https://hg.libsdl.org/SDL_image/rev/cf211e9ff224 