### PR TITLE
Adding missing SysWMType entries

### DIFF
--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -302,7 +302,7 @@ type
   RendererFlip* = cint
   SysWMType* {.size: sizeof(cint).}=enum
     SysWM_Unknown, SysWM_Windows, SysWM_X11, SysWM_DirectFB,
-    SysWM_Cocoa, SysWM_UIkit
+    SysWM_Cocoa, SysWM_UIkit, SysWM_Android
   WMinfo* = object
     version*: SDL_Version
     subsystem*: SysWMType

--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -302,7 +302,7 @@ type
   RendererFlip* = cint
   SysWMType* {.size: sizeof(cint).}=enum
     SysWM_Unknown, SysWM_Windows, SysWM_X11, SysWM_DirectFB,
-    SysWM_Cocoa, SysWM_UIkit, SysWM_Android
+    SysWM_Cocoa, SysWM_UIkit, SysWM_Wayland, SysWM_Mir, SysWM_WinRT, SysWM_Android, SysWM_Vivante
   WMinfo* = object
     version*: SDL_Version
     subsystem*: SysWMType


### PR DESCRIPTION
These are missing and required for detecting various subsystems via SDL2.