### PR TITLE
Remove deprecated expr

### DIFF
--- a/src/sdl2/mixer.nim
+++ b/src/sdl2/mixer.nim
@@ -140,7 +140,7 @@ proc querySpec*(frequency: ptr cint; format: ptr uint16; channels: ptr cint): ci
 
 proc loadWAV_RW*(src: RWopsPtr; freesrc: cint): ptr Chunk {.importc: "Mix_LoadWAV_RW".}
 
-template loadWAV*(file: expr): expr =
+template loadWAV*(file: untyped): untyped =
   loadWAV_RW(rwFromFile(file, "rb"), 1)
 
 proc loadMUS*(file: cstring): ptr Music {.importc: "Mix_LoadMUS".}
@@ -535,7 +535,7 @@ proc playChannelTimed*(channel: cint; chunk: ptr Chunk; loops: cint;
 
 # The same as above, but the sound is played forever
 
-template playChannel*(channel, chunk, loops: expr): expr =
+template playChannel*(channel, chunk, loops: untyped): untyped =
   playChannelTimed(channel, chunk, loops, - 1)
 
 proc playMusic*(music: ptr Music; loops: cint): cint {.importc: "Mix_PlayMusic".}
@@ -544,7 +544,7 @@ proc playMusic*(music: ptr Music; loops: cint): cint {.importc: "Mix_PlayMusic".
 proc fadeInMusic*(music: ptr Music; loops: cint; ms: cint): cint {.importc: "Mix_FadeInMusic".}
 proc fadeInMusicPos*(music: ptr Music; loops: cint; ms: cint;
                          position: cdouble): cint {.importc: "Mix_FadeInMusicPos".}
-template fadeInChannel*(channel, chunk, loops, ms: expr): expr =
+template fadeInChannel*(channel, chunk, loops, ms: untyped): untyped =
   fadeInChannelTimed(channel, chunk, loops, ms, - 1)
 
 proc fadeInChannelTimed*(channel: cint; chunk: ptr Chunk; loops: cint;

--- a/src/sdl2/private/keycodes.nim
+++ b/src/sdl2/private/keycodes.nim
@@ -116,7 +116,7 @@ type
                             #                                 for array bounds
 
 const SDLK_SCANCODE_MASK = 1 shl 30
-template SDL_SCANCODE_TO_KEYCODE(some: ScanCode): expr = (some.cint or SDLK_SCANCODE_MASK)
+template SDL_SCANCODE_TO_KEYCODE(some: ScanCode): untyped = (some.cint or SDLK_SCANCODE_MASK)
 
 const
   K_UNKNOWN*: cint = 0
@@ -390,10 +390,10 @@ type
 
 converter toInt*(some: Keymod): cint = cint(some)
 
-template KMOD_CTRL*: expr = (KMOD_LCTRL or KMOD_RCTRL)
-template KMOD_SHIFT*:expr = (KMOD_LSHIFT or KMOD_RSHIFT)
-template KMOD_ALT*: expr = (KMOD_LALT or KMOD_RALT)
-template KMOD_GUI*: expr = (KMOD_LGUI or KMOD_RGUI)
+template KMOD_CTRL*: untyped = (KMOD_LCTRL or KMOD_RCTRL)
+template KMOD_SHIFT*:untyped = (KMOD_LSHIFT or KMOD_RSHIFT)
+template KMOD_ALT*: untyped = (KMOD_LALT or KMOD_RALT)
+template KMOD_GUI*: untyped = (KMOD_LGUI or KMOD_RGUI)
 
 {.deprecated: [TScancode: Scancode].}
 {.deprecated: [TKeymod: Keymod].}


### PR DESCRIPTION
I replaced the ``expr`` keyword with untyped. I'm not sure if I should be using ``typed`` in some of these cases or not.