### PR TITLE
Created the bones of a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,8 @@ Install SDL2 development libraries using your distribution's packaging tool of c
 TODO
 
 # Installation
-Add the `sdl2` nim package to your nimble package configuration, or install it by hand using `nimble install`. For more information on using nimble, consult [the nim documentation](https://nim-lang.org/docs/lib.html#nimble).
+Add `requires "sdl2"` to your `.nimble` file.
+
+You can also install manually with `nimble install sdl2` if your project does not yet have a nimble package file.
+
+For more information on using nimble, consult [the nim documentation](https://nim-lang.org/docs/lib.html#nimble).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# SDL2 for Nim
+This package contains the bindings for SDL2 to Nim.
+
+# Pre-requisites
+You must install the SDL2 C libraries before these Nim bindings can be used.
+
+## macOS with Homebrew
+If you don't already have Homebrew installed, install it from [the Homebrew site](https://brew.sh/).
+
+Install the SDL2 C libraries:
+
+```bash
+brew install sdl2{,_gfx,_image,_mixer,_net,_ttf}
+```
+
+## Linux
+Install SDL2 development libraries using your distribution's packaging tool of choice.
+
+## Windows
+TODO
+
+# Installation
+Add the `sdl2` nim package to your nimble package configuration, or install it by hand using `nimble install`. For more information on using nimble, consult [the nim documentation](https://nim-lang.org/docs/lib.html#nimble).


### PR DESCRIPTION
Added a simple README because I wanted to document a bit about using this.

For other people, as it was for me, the SDL2 bindings might be the first serious exposure to nimble. I was considering adding some quick documentation about how to create a nimble file using `nimble init` but wasn't sure if that was too much detail that would add to maintenance later if nimble ever changed.

For now, I've just documented the native dependencies and said a little blurb.