### PR TITLE
Fixing broken  statement so that  can be compiled

### DIFF
--- a/src/sdl2/mixer.nim
+++ b/src/sdl2/mixer.nim
@@ -448,7 +448,7 @@ proc setDistance*(channel: cint; distance: uint8): cint {.importc: "Mix_SetDista
 #                --ryan.
 #
 
-when 0:
+when false:
   # Causes an echo effect to be mixed into a sound. (echo) is the amount
   #   of echo to mix. 0 is no echo, 255 is infinite (and probably not
   #   what you want).


### PR DESCRIPTION
This should fix the compilation error that you get when trying to build a project that uses `sdl2/mixer.nim`.