### PR TITLE
fix regression: invalid proc quit()* => proc quit*()

### DIFF
--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -847,7 +847,7 @@ proc quitSubSystem*(flags: uint32) {.
 proc wasInit*(flags: uint32): uint32 {.
   importc: "SDL_WasInit".}
 
-proc quit()* {.
+proc quit*() {.
   importc: "SDL_Quit".}
 
 proc getPlatform*(): cstring {.


### PR DESCRIPTION
/cc @krux02 
fixes regression introduced in d0537fcc7da798afb94d76331b92fed2ee184e74
