### PR TITLE
bump version because of prior bugfix after a published release

### DIFF
--- a/sdl2.nimble
+++ b/sdl2.nimble
@@ -1,5 +1,5 @@
 # Package
-version = "2.0"
+version = "2.0.1"
 author = "fowl"
 description = "Wrapper for SDL 2.x"
 license = "MIT"


### PR DESCRIPTION
(a prior git tag was published at 2.0 the forced-pushed again at 2.0 after new commits; even though it may affect not many users, there's no reason to re-released a published version as was done here: https://github.com/nim-lang/sdl2/pull/112#issuecomment-436763824 )

rationale:
see comment from @Araq  here: https://github.com/nim-lang/sdl2/issues/113#issuecomment-437152083

> The Nimble version shouldn't be based on the version of the originally wrapped library, that ignores how the Nim wrapping mechanism works. Only accessed symbols are dlsym'ed so wrapping SDL 2.0.10 and accessing a SDL_2.0.1.dll works as long as you don't use a feature that 2.0.1 lacks.

supersedes https://github.com/nim-lang/sdl2/pull/112 and https://github.com/nim-lang/sdl2/issues/113