### PR TITLE
Update lib name on OpenBSD

### DIFF
--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -16,6 +16,8 @@ else:
     const LibName* = "SDL2.dll"
   elif defined(macosx):
     const LibName* = "libSDL2.dylib"
+  elif defined(openbsd):
+    const LibName* = "libSDL2.so.0.6"
   else:
     const LibName* = "libSDL2.so"
 


### PR DESCRIPTION
Related to https://github.com/nim-lang/Nim/pull/12143 - OpenBSD creates `/usr/local/lib/libSDL2.so.0.6` when using `pkg_add sdl2`, but not `/usr/local/lib/libSDL2.so`.