### PR TITLE
Fix csize warnings

### DIFF
--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -24,12 +24,6 @@ else:
 {.pop.}
 
 
-when not defined(android) and not defined(ios):
-  type csize_t_const* = csize_t
-else:
-  type csize_t_const* = csize
-
-
 include sdl2/private/keycodes
 
 const
@@ -716,9 +710,9 @@ type
   RWops* {.pure, final.} = object
     size*: proc (context: RWopsPtr): int64 {.cdecl, tags: [], raises: [].}
     seek*: proc (context: RWopsPtr; offset: int64; whence: cint): int64 {.cdecl, tags: [], raises: [].}
-    read*: proc (context: RWopsPtr; destination: pointer; size, maxnum: csize_t_const): csize_t_const {.cdecl, tags: [ReadIOEffect], raises: [].}
-    write*: proc (context: RWopsPtr; source: pointer; size: csize_t_const;
-                  num: csize_t_const): csize_t_const {.cdecl, tags: [WriteIOEffect], raises: [].}
+    read*: proc (context: RWopsPtr; destination: pointer; size, maxnum: csize_t): csize_t {.cdecl, tags: [ReadIOEffect], raises: [].}
+    write*: proc (context: RWopsPtr; source: pointer; size: csize_t;
+                  num: csize_t): csize_t {.cdecl, tags: [WriteIOEffect], raises: [].}
     close*: proc (context: RWopsPtr): cint {.cdecl, tags: [WriteIOEffect].}
     kind*: cint
     mem*: Mem
@@ -1191,13 +1185,13 @@ proc readLE32*(src: RWopsPtr): uint32 {.importc: "SDL_ReadLE32".}
 proc readBE32*(src: RWopsPtr): uint32 {.importc: "SDL_ReadBE32".}
 proc readLE64*(src: RWopsPtr): uint64 {.importc: "SDL_ReadLE64".}
 proc readBE64*(src: RWopsPtr): uint64 {.importc: "SDL_ReadBE64".}
-proc writeU8*(dst: RWopsPtr; value: uint8): csize_t_const {.importc: "SDL_WriteU8".}
-proc writeLE16*(dst: RWopsPtr; value: uint16): csize_t_const {.importc: "SDL_WriteLE16".}
-proc writeBE16*(dst: RWopsPtr; value: uint16): csize_t_const {.importc: "SDL_WriteBE16".}
-proc writeLE32*(dst: RWopsPtr; value: uint32): csize_t_const {.importc: "SDL_WriteLE32".}
-proc writeBE32*(dst: RWopsPtr; value: uint32): csize_t_const {.importc: "SDL_WriteBE32".}
-proc writeLE64*(dst: RWopsPtr; value: uint64): csize_t_const {.importc: "SDL_WriteLE64".}
-proc writeBE64*(dst: RWopsPtr; value: uint64): csize_t_const {.importc: "SDL_WriteBE64".}
+proc writeU8*(dst: RWopsPtr; value: uint8): csize_t {.importc: "SDL_WriteU8".}
+proc writeLE16*(dst: RWopsPtr; value: uint16): csize_t {.importc: "SDL_WriteLE16".}
+proc writeBE16*(dst: RWopsPtr; value: uint16): csize_t {.importc: "SDL_WriteBE16".}
+proc writeLE32*(dst: RWopsPtr; value: uint32): csize_t {.importc: "SDL_WriteLE32".}
+proc writeBE32*(dst: RWopsPtr; value: uint32): csize_t {.importc: "SDL_WriteBE32".}
+proc writeLE64*(dst: RWopsPtr; value: uint64): csize_t {.importc: "SDL_WriteLE64".}
+proc writeBE64*(dst: RWopsPtr; value: uint64): csize_t {.importc: "SDL_WriteBE64".}
 
 proc showMessageBox*(messageboxdata: ptr MessageBoxData;
   buttonid: var cint): cint {.importc: "SDL_ShowMessageBox".}
@@ -1846,9 +1840,9 @@ proc size* (ctx:RWopsPtr): int64 {.inline.} =
   ctx.size(ctx)
 proc seek* (ctx:RWopsPtr; offset:int64; whence:cint): int64 {.inline.} =
   ctx.seek(ctx,offset,whence)
-proc read* (ctx:RWopsPtr; `ptr`: pointer; size,maxnum:csize_t_const): csize_t_const{.inline.} =
+proc read* (ctx:RWopsPtr; `ptr`: pointer; size,maxnum:csize_t): csize_t{.inline.} =
   ctx.read(ctx, `ptr`, size, maxnum)
-proc write* (ctx:RWopsPtr; `ptr`:pointer; size,num:csize_t_const): csize_t_const{.inline.} =
+proc write* (ctx:RWopsPtr; `ptr`:pointer; size,num:csize_t): csize_t{.inline.} =
   ctx.write(ctx, `ptr`, size, num)
 proc close* (ctx:RWopsPtr): cint {.inline.} =
   ctx.close(ctx)

--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -23,6 +23,13 @@ else:
 
 {.pop.}
 
+
+when not defined(android) and not defined(ios):
+  type csize_t_const* = csize_t
+else:
+  type csize_t_const* = csize
+
+
 include sdl2/private/keycodes
 
 const
@@ -568,7 +575,7 @@ type
     refcount*: cint
     next*: ptr PixelFormat
 
-  BlitMapPtr* = ptr object{.pure.} ##couldnt find SDL_BlitMap ?
+  BlitMapPtr*{.pure.} = ptr object ##couldnt find SDL_BlitMap ?
 
   SurfacePtr* = ptr Surface
   Surface* {.pure, final.} = object
@@ -709,9 +716,9 @@ type
   RWops* {.pure, final.} = object
     size*: proc (context: RWopsPtr): int64 {.cdecl, tags: [], raises: [].}
     seek*: proc (context: RWopsPtr; offset: int64; whence: cint): int64 {.cdecl, tags: [], raises: [].}
-    read*: proc (context: RWopsPtr; destination: pointer; size, maxnum: csize): csize {.cdecl, tags: [ReadIOEffect], raises: [].}
-    write*: proc (context: RWopsPtr; source: pointer; size: csize;
-                  num: csize): csize {.cdecl, tags: [WriteIOEffect], raises: [].}
+    read*: proc (context: RWopsPtr; destination: pointer; size, maxnum: csize_t_const): csize_t_const {.cdecl, tags: [ReadIOEffect], raises: [].}
+    write*: proc (context: RWopsPtr; source: pointer; size: csize_t_const;
+                  num: csize_t_const): csize_t_const {.cdecl, tags: [WriteIOEffect], raises: [].}
     close*: proc (context: RWopsPtr): cint {.cdecl, tags: [WriteIOEffect].}
     kind*: cint
     mem*: Mem
@@ -1184,13 +1191,13 @@ proc readLE32*(src: RWopsPtr): uint32 {.importc: "SDL_ReadLE32".}
 proc readBE32*(src: RWopsPtr): uint32 {.importc: "SDL_ReadBE32".}
 proc readLE64*(src: RWopsPtr): uint64 {.importc: "SDL_ReadLE64".}
 proc readBE64*(src: RWopsPtr): uint64 {.importc: "SDL_ReadBE64".}
-proc writeU8*(dst: RWopsPtr; value: uint8): csize {.importc: "SDL_WriteU8".}
-proc writeLE16*(dst: RWopsPtr; value: uint16): csize {.importc: "SDL_WriteLE16".}
-proc writeBE16*(dst: RWopsPtr; value: uint16): csize {.importc: "SDL_WriteBE16".}
-proc writeLE32*(dst: RWopsPtr; value: uint32): csize {.importc: "SDL_WriteLE32".}
-proc writeBE32*(dst: RWopsPtr; value: uint32): csize {.importc: "SDL_WriteBE32".}
-proc writeLE64*(dst: RWopsPtr; value: uint64): csize {.importc: "SDL_WriteLE64".}
-proc writeBE64*(dst: RWopsPtr; value: uint64): csize {.importc: "SDL_WriteBE64".}
+proc writeU8*(dst: RWopsPtr; value: uint8): csize_t_const {.importc: "SDL_WriteU8".}
+proc writeLE16*(dst: RWopsPtr; value: uint16): csize_t_const {.importc: "SDL_WriteLE16".}
+proc writeBE16*(dst: RWopsPtr; value: uint16): csize_t_const {.importc: "SDL_WriteBE16".}
+proc writeLE32*(dst: RWopsPtr; value: uint32): csize_t_const {.importc: "SDL_WriteLE32".}
+proc writeBE32*(dst: RWopsPtr; value: uint32): csize_t_const {.importc: "SDL_WriteBE32".}
+proc writeLE64*(dst: RWopsPtr; value: uint64): csize_t_const {.importc: "SDL_WriteLE64".}
+proc writeBE64*(dst: RWopsPtr; value: uint64): csize_t_const {.importc: "SDL_WriteBE64".}
 
 proc showMessageBox*(messageboxdata: ptr MessageBoxData;
   buttonid: var cint): cint {.importc: "SDL_ShowMessageBox".}
@@ -1839,9 +1846,9 @@ proc size* (ctx:RWopsPtr): int64 {.inline.} =
   ctx.size(ctx)
 proc seek* (ctx:RWopsPtr; offset:int64; whence:cint): int64 {.inline.} =
   ctx.seek(ctx,offset,whence)
-proc read* (ctx:RWopsPtr; `ptr`: pointer; size,maxnum:csize): csize{.inline.} =
+proc read* (ctx:RWopsPtr; `ptr`: pointer; size,maxnum:csize_t_const): csize_t_const{.inline.} =
   ctx.read(ctx, `ptr`, size, maxnum)
-proc write* (ctx:RWopsPtr; `ptr`:pointer; size,num:csize): csize{.inline.} =
+proc write* (ctx:RWopsPtr; `ptr`:pointer; size,num:csize_t_const): csize_t_const{.inline.} =
   ctx.write(ctx, `ptr`, size, num)
 proc close* (ctx:RWopsPtr): cint {.inline.} =
   ctx.close(ctx)

--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -569,7 +569,7 @@ type
     refcount*: cint
     next*: ptr PixelFormat
 
-  BlitMapPtr*{.pure.} = ptr object ##couldnt find SDL_BlitMap ?
+  BlitMapPtr* {.pure.} = ptr object ##couldnt find SDL_BlitMap ?
 
   SurfacePtr* = ptr Surface
   Surface* {.pure, final.} = object

--- a/src/sdl2/ttf.nim
+++ b/src/sdl2/ttf.nim
@@ -13,7 +13,7 @@ else:
 import sdl2
 
 type
-  FontPtr* = ptr object{.pure.}
+  FontPtr* {.pure.} = ptr object
 
 # Set up for C function definitions, even when using C++
 # Printable format: "%d.%d.%d", MAJOR, MINOR, PATCHLEVEL


### PR DESCRIPTION
I fixed some errors and warnings.
``Warning: use `csize_t` instead; csize is deprecated [Deprecated]`` (Nim v1.3.5)
Termux on Android 6.0 says that `csize` is not declared. (Nim v1.0.4)