### PR TITLE
Fix Linux library patterns.

### DIFF
--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -23,7 +23,7 @@ else:
   elif defined(haiku):
     const LibName* = "libSDL2-2.0.so.0"
   else:
-    const LibName* = "libSDL2.so"
+    const LibName* = "libSDL2(|-2.0).so(|.0)"
 
 {.pop.}
 

--- a/src/sdl2/gfx.nim
+++ b/src/sdl2/gfx.nim
@@ -35,7 +35,7 @@ when not defined(SDL_Static):
   elif defined(macosx):
     const LibName = "libSDL2_gfx.dylib"
   else:
-    const LibName = "libSDL2_gfx(|-2.0).so(|.0)"
+    const LibName = "libSDL2_gfx(|-1.0).so(|.0)"
 else:
   static: echo "SDL_Static option is deprecated and will soon be removed. Instead please use --dynlibOverride:SDL2_gfx."
 


### PR DESCRIPTION
I changed the pattern of the main library to support versioned names so you don't need to install development packages to run the application. I also changed the pattern of SDL2_gfx because it uses a different versioning scheme which is reflected in the so name.