### PR TITLE
fix: lower case first letter of type

### DIFF
--- a/src/sdl2/gamecontroller.nim
+++ b/src/sdl2/gamecontroller.nim
@@ -287,7 +287,7 @@ proc rumble*(gamecontroller: GameControllerPtr,
   ## `Returns` 0, or -1 if rumble isn't supported on this controller
 
 proc rumbleTriggers*(gamecontroller: GameControllerPtr,
-  leftRumble, rightRue: uint16, durationMs: Uint32): cint {.
+  leftRumble, rightRue: uint16, durationMs: uint32): cint {.
   importc: "SDL_GameControllerRumbleTriggers".}
   ## Start a rumble effect in the game controller's triggers.
   ##

--- a/src/sdl2/gamecontroller.nim
+++ b/src/sdl2/gamecontroller.nim
@@ -274,7 +274,7 @@ proc getButton*(
   ##
   ## The button indices start at index `0`.
 
-proc rumble*(gamecontroller: GameControllerPtr,
+proc gameControllerRumble*(gamecontroller: GameControllerPtr,
   lowFrequencyRumble, highFrequencyRUmble: uint16,
   durationMs: uint32): SDL_Return {.
   importc: "SDL_GameControllerRumble".}
@@ -286,7 +286,7 @@ proc rumble*(gamecontroller: GameControllerPtr,
   ##
   ## `Returns` 0, or -1 if rumble isn't supported on this controller
 
-proc rumbleTriggers*(gamecontroller: GameControllerPtr,
+proc gameControllerRumbleTriggers*(gamecontroller: GameControllerPtr,
   leftRumble, rightRue: uint16, durationMs: uint32): cint {.
   importc: "SDL_GameControllerRumbleTriggers".}
   ## Start a rumble effect in the game controller's triggers.
@@ -301,35 +301,35 @@ proc rumbleTriggers*(gamecontroller: GameControllerPtr,
   ##
   ## `Returns` 0, or -1 if trigger rumble isn't supported on this controller
 
-proc hasLED*(gamecontroller: GameControllerPtr): Bool32 {.
+proc gameControllerHasLED*(gamecontroller: GameControllerPtr): Bool32 {.
   importc: "SDL_GameControllerHasLED".}
   ## Query whether a game controller has an LED.
   ##
   ## \returns SDL_TRUE, or SDL_FALSE if this controller does not have a
   ##          modifiable LED
 
-proc hasRumble*(gamecontroller: GameControllerPtr): Bool32 {.
+proc gameControllerHasRumble*(gamecontroller: GameControllerPtr): Bool32 {.
   importc: "SDL_GameControllerHasRumble".}
   ## Query whether a game controller has rumble support.
   ##
   ## `Returns` `True32`, or `False32` if this controller does not have rumble
   ##           support
 
-proc hasRumbleTriggers*(gamecontroller: GameControllerPtr) {.
+proc gameControllerHasRumbleTriggers*(gamecontroller: GameControllerPtr) {.
   importc: "SDL_GameControllerHasRumbleTriggers".}
   ## Query whether a game controller has rumble support on triggers.
   ##
   ## `Returns` `True32`, or `False32` if this controller does not have trigger
   ##           rumble support
 
-proc setLED*(gamecontroller: GameControllerPtr, red, green,
+proc gameControllerSetLED*(gamecontroller: GameControllerPtr, red, green,
     blue: uint8) {.
   importc: "SDL_GameControllerSetLED".}
   ## Update a game controller's LED color.
   ##
   ## `Returns` 0, or -1 if this controller does not have a modifiable LED
 
-proc sendEffect*(gamecontroller: GameControllerPtr, data: pointer,
+proc gameControllerSendEffect*(gamecontroller: GameControllerPtr, data: pointer,
     size: cint): cint {.
   importc: "SDL_GameControllerSendEffect".}
   ## Send a controller specific effect packet
@@ -337,7 +337,7 @@ proc sendEffect*(gamecontroller: GameControllerPtr, data: pointer,
   ## `Returns` 0, or -1 if this controller or driver doesn't support effect
   ##           packets
 
-proc getAppleSFSymbolsNameForButton*(
+proc gameControllerGetAppleSFSymbolsNameForButton*(
   gamecontroller: GameControllerPtr, button: GameControllerButton): cstring {.
   importc: "SDL_GameControllerGetAppleSFSymbolsNameForButton".}
   ## Return the sfSymbolsName for a given button on a game controller on Apple
@@ -346,7 +346,7 @@ proc getAppleSFSymbolsNameForButton*(
   ## `Returns` the sfSymbolsName or `nil` if the name can't be found
 
 
-proc getAppleSFSymbolsNameForAxis*(
+proc gameControllerGetAppleSFSymbolsNameForAxis*(
   gamecontroller: GameControllerPtr, axis: GameControllerAxis): cstring {.
   importc: "SDL_GameControllerGetAppleSFSymbolsNameForAxis".}
   ## Return the sfSymbolsName for a given axis on a game controller on Apple

--- a/src/sdl2/gamecontroller.nim
+++ b/src/sdl2/gamecontroller.nim
@@ -67,7 +67,7 @@ when defined(SDL_Static):
 else:
   {.push callConv: cdecl, dynlib: LibName.}
 
-  proc addMappingsFromRW*(rw: RWopsPtr,
+  proc gameControllerAddMappingsFromRW*(rw: RWopsPtr,
     freerw: cint): cint {.importc: "SDL_GameControllerAddMappingsFromRW".}
     ##
     ## Load a set of Game Controller mappings from a seekable SDL data stream.
@@ -88,19 +88,19 @@ else:
     ##
     ## `Return` the number of mappings added or -1 on error
 
-  template addMappingsFromFile*(filename: untyped): untyped =
+  template gameControllerAddMappingsFromFile*(filename: untyped): untyped =
     gameControllerAddMappingsFromRW(rwFromFile(filename, "rb"), 1)
     ## Load a set of mappings from a file, filtered by the current `GetPlatform`
     ##
     ## Convenience macro.
 
-proc addMapping*(mappingString: cstring): cint {.
+proc gameControllerAddMapping*(mappingString: cstring): cint {.
   importc: "SDL_GameControllerAddMapping".}
   ## Add or update an existing mapping configuration.
   ##
   ## `Return` `1` if mapping is added, `0` if updated, `-1` on error.
 
-proc mappingForGUID*(guid: JoystickGuid): cstring {.
+proc gameControllerMappingForGUID*(guid: JoystickGuid): cstring {.
   importc: "SDL_GameControllerMappingForGUID".}
   ## Get a mapping string for a GUID.
   ##
@@ -118,14 +118,14 @@ proc isGameController*(joystickIndex: cint): Bool32 {.
   importc: "SDL_IsGameController".}
   ## Is the joystick on this index supported by the game controller interface?
 
-proc nameForIndex*(joystickIndex: cint): cstring {.
+proc gameControllerNameForIndex*(joystickIndex: cint): cstring {.
   importc: "SDL_GameControllerNameForIndex".}
   ## Get the implementation dependent name of a game controller.
   ##
   ## This can be called before any controllers are opened.
   ## If no name can be found, this procedure returns `nil`.
 
-proc open*(joystickIndex: cint): GameControllerPtr {.
+proc gameControllerOpen*(joystickIndex: cint): GameControllerPtr {.
   importc: "SDL_GameControllerOpen".}
   ## Open a game controller for use.
   ##
@@ -138,7 +138,7 @@ proc open*(joystickIndex: cint): GameControllerPtr {.
   ##
   ## `Return` a controller identifier, or `nil` if an error occurred.
 
-proc fromInstanceID*(joyid: JoystickID): GameControllerPtr {.
+proc gameControllerFromInstanceID*(joyid: JoystickID): GameControllerPtr {.
   importc: "SDL_GameControllerFromInstanceID".}
   ## Get the GameControllerPtr associated with an instance id.
   ##
@@ -157,7 +157,7 @@ proc getJoystick*(gameController: GameControllerPtr): JoystickPtr {.
   importc: "SDL_GameControllerGetJoystick".}
   ## Get the underlying joystick object used by a controller.
 
-proc eventState*(state: cint): cint {.
+proc gameControllerEventState*(state: cint): cint {.
   importc: "SDL_GameControllerEventState".}
   ## Enable/disable controller event polling.
   ##
@@ -168,7 +168,7 @@ proc eventState*(state: cint): cint {.
   ## The state can be one of `SDL_QUERY`, `SDL_ENABLE` or `SDL_IGNORE`.
 
 
-proc update*() {.importc: "SDL_GameControllerUpdate".}
+proc gameControllerUpdate*() {.importc: "SDL_GameControllerUpdate".}
   ## Update the current state of the open game controllers.
   ##
   ## This is called automatically by the event loop if any game controller
@@ -196,13 +196,13 @@ type
 
 converter toInt*(some: GameControllerAxis): uint8 = uint8(some)
 
-proc getAxisFromString*(pchString: cstring): GameControllerAxis {.
+proc gameControllerGetAxisFromString*(pchString: cstring): GameControllerAxis {.
   importc: "SDL_GameControllerGetAxisFromString".}
 proc getAxisFromString*(pchString: cstring): GameControllerAxis {.
   importc: "SDL_GameControllerGetAxisFromString".}
   ## Turn this string into a axis mapping.
 
-proc getStringForAxis*(axis: GameControllerAxis): cstring {.
+proc gameControllerGetStringForAxis*(axis: GameControllerAxis): cstring {.
   importc: "SDL_GameControllerGetStringForAxis".}
 proc getStringForAxis*(axis: GameControllerAxis): cstring {.
   importc: "SDL_GameControllerGetStringForAxis".}
@@ -246,14 +246,14 @@ type
 
 converter toInt*(some: GameControllerButton): uint8 = uint8(some)
 
-proc getButtonFromString*(
+proc gameControllerGetButtonFromString*(
   pchString: cstring): GameControllerButton {.
   importc: "SDL_GameControllerGetButtonFromString".}
 proc getButtonFromString*(pchString: cstring): GameControllerButton {.
   importc: "SDL_GameControllerGetButtonFromString".}
   ## Turn this string into a button mapping.
 
-proc getStringForButton*(
+proc gameControllerGetStringForButton*(
   button: GameControllerButton): cstring {.
   importc: "SDL_GameControllerGetStringForButton".}
 proc getStringForButton*(button: GameControllerButton): cstring {.


### PR DESCRIPTION
Hello

@Araq 

this pr does three small things, one per commit:

1. [481de45](https://github.com/BarrOff/sdl2/commit/481de4502cb1d587c554a7e52e7e091e28f3575d) fixes a typo in a parameter type (I used `Uint32` instead of `uint32`)
2. [98d8ce9](https://github.com/BarrOff/sdl2/commit/98d8ce953db06e623f12bd7a285c7b7358862621) partly reverts my [commit](https://github.com/nim-lang/sdl2/commit/a71b87524a25bb6c0a9b0e2821a922bb62bd316b) which removed the `gameController` prefix from some procs. I found this to cause multiple problems:

   - this was a backwards incompatible change
   - I did not change it in all places so there were remains using the old names
   - it does not seem to suit the naming conventions. Looking at the [joystick code](https://github.com/nim-lang/sdl2/blob/master/src/sdl2/joystick.nim), it seems to be convention to prepend the device, just like it is in the C code. For some selected procs extra versions without the prefix are created but not for all. 

3. [e6b80c4](https://github.com/BarrOff/sdl2/commit/e6b80c4921328052072f23dca4d8ba1bd4881b48) adjusts the new gameController proc names from [commit](https://github.com/nim-lang/sdl2/commit/a71b87524a25bb6c0a9b0e2821a922bb62bd316b) to use the prefix. If versions without it are deemed worth it, they can be added later.