### PR TITLE
refactor: make gameControllerAddMappingsFromFile a proc

### DIFF
--- a/src/sdl2/gamecontroller.nim
+++ b/src/sdl2/gamecontroller.nim
@@ -88,8 +88,8 @@ else:
     ##
     ## `Return` the number of mappings added or -1 on error
 
-  template gameControllerAddMappingsFromFile*(filename: untyped): untyped =
-    gameControllerAddMappingsFromRW(rwFromFile(filename, "rb"), 1)
+  proc gameControllerAddMappingsFromFile*(filename: cstring): cint =
+    return gameControllerAddMappingsFromRW(rwFromFile(filename, "rb"), 1)
     ## Load a set of mappings from a file, filtered by the current `GetPlatform`
     ##
     ## Convenience macro.


### PR DESCRIPTION
[SDL_GameControllerAddMappingsFromFile](https://wiki.libsdl.org/SDL2/SDL_GameControllerAddMappingsFromFile) is a macro in C, that's why I initially implemented it as a template but there is no need to do so.
Therefore I refactored it as a proc to make the code simpler.

I also verified with a small example project that it still works.