### PR TITLE
Add the function createRGBSurfaceWithFormatFrom to sdl2.nim

### DIFF
--- a/src/sdl2.nim
+++ b/src/sdl2.nim
@@ -2444,6 +2444,10 @@ proc createRGBSurfaceFrom*(pixels: pointer; width, height, depth, pitch: cint;
   Rmask, Gmask, Bmask, Amask: uint32): SurfacePtr {.
   importc: "SDL_CreateRGBSurfaceFrom".}
 
+proc createRGBSurfaceWithFormatFrom*(pixels: pointer; width, height, depth, pitch: cint;
+  format: uint32): SurfacePtr {.
+  importc: "SDL_CreateRGBSurfaceWithFormatFrom".}
+
 proc freeSurface*(surface: SurfacePtr) {.importc: "SDL_FreeSurface".}
 
 proc setSurfacePalette*(surface: SurfacePtr; palette: ptr Palette): cint {.


### PR DESCRIPTION
This function is very helpful when create RGBA32 surface from PNG.

In my case
this code is not working,
ignore alpha channel and display white pixels instead transparent pixels
```
surfacePixels = SDL_CreateRGBSurfaceFrom(pixels, w, h, 32, w*4, 0x000000ff, 0x0000ff00, 0x00ff0000, 0);
surfacePixels = SDL_ConvertSurfaceFormat(surfacePixels, SDL_PIXELFORMAT_ABGR8888, 0);
```

but
this code is working correctly
```
surfacePixels = SDL_CreateRGBSurfaceWithFormatFrom(pixels, w, h, 32, w*4, SDL_PIXELFORMAT_ABGR8888);
```
There must be a correct way to do this, but the procedure is complicated, so I would like it to be added.

